### PR TITLE
fix: disable nav items until agent chat is complete

### DIFF
--- a/src/components/AppNavigation.vue
+++ b/src/components/AppNavigation.vue
@@ -12,9 +12,11 @@ import {
 } from '@/components/ui/sheet'
 import { storeToRefs } from 'pinia'
 import { useNavigationStore } from '@/stores/navigation'
+import { useAgentChatStore } from '@/stores/agentChat'
 import type { Component } from 'vue'
 
 const { navOpen } = storeToRefs(useNavigationStore())
+const { isComplete } = storeToRefs(useAgentChatStore())
 
 const router = useRouter()
 
@@ -29,6 +31,10 @@ const iconMap: Record<string, Component> = {
 function navigateTo(path: string) {
   router.push(path)
   navOpen.value = false
+}
+
+function isItemDisabled(path: string) {
+  return path !== '/' && !isComplete.value
 }
 </script>
 
@@ -45,13 +51,21 @@ function navigateTo(path: string) {
           :key="item.path"
           variant="ghost"
           class="justify-start gap-3 text-foreground hover:bg-secondary hover:text-secondary-foreground"
-          :class="$route.path === item.path && 'bg-secondary text-secondary-foreground font-semibold'"
+          :class="[
+            $route.path === item.path && 'bg-secondary text-secondary-foreground font-semibold',
+            isItemDisabled(item.path) && 'opacity-40 cursor-not-allowed pointer-events-none',
+          ]"
+          :disabled="isItemDisabled(item.path)"
+          :title="isItemDisabled(item.path) ? 'Complete the meal planning chat to unlock' : undefined"
           @click="navigateTo(item.path)"
         >
           <component :is="iconMap[item.icon]" class="h-5 w-5" />
           {{ item.label }}
         </Button>
       </nav>
+      <p v-if="!isComplete" class="mt-4 px-2 text-xs text-muted-foreground">
+        Complete the meal planning chat to unlock all pages.
+      </p>
     </SheetContent>
   </Sheet>
 </template>


### PR DESCRIPTION
Fixes #1

Nav items other than Meal Agent are now visually disabled when the agent chat is not yet complete, preventing the silent redirect caused by the router guard.

Generated with [Claude Code](https://claude.ai/code)